### PR TITLE
k8s deploy using latest tags instead of changes to main branch

### DIFF
--- a/kubernetes/deployment-production.yaml
+++ b/kubernetes/deployment-production.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: subject-set-search-api-production-app
-          image: zooniverse/subject-set-search-api:__IMAGE_TAG__
+          image: zooniverse/subject-set-search-api:latest
           resources:
              requests:
                memory: "250Mi"
@@ -26,6 +26,7 @@ spec:
                cpu: "1000m"
           ports:
             - containerPort: 80
+          imagePullPolicy: Always
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Currently in order to ensure the rebuild subject set data deploys correctly to our K8s cluster we need to ensure the git SHA of the main branch changes. E.g. https://github.com/zooniverse/subject-set-search-api/commit/f6359d31298d70ebdab304b1be8a58785c1b4f62

Preferably we should be able to press `rebuild` in jenkins (or GH actions UI) to ensure these new data changes are deployed correctly. 

As such this PR is trying a new technique to allow us to use the jenkins rebuild feature to deploy changes. 

It achieves this by 
- using the `latest` image tag in the k8s deployment spec
- combined with the pod directive to always pull a the container image `imagePullPolicy: Always`
- and then ensure new containers are created by rollout restarting a deployment 

A by product of this is that the jenkins system no longer needs to inject the GIT_COMMIT into the deployment file, instead it can run the yaml file directly. However note that without the `rollout restart deployment` cmd the pods won't recreate as the spec template won't have changed.