### PR TITLE
add a BUILD_DATE arg to invalidate the image layer cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,17 @@ WORKDIR /mnt/datasette
 # for geojson api responses - https://pypi.org/project/geojson/
 RUN pip install csvs-to-sqlite sqlite-utils panoptes-client
 
+# add BUILD_DATE arg to invalidate the cache
+ARG BUILD_DATE=''
+# bake this into the image for reference
+ENV BUILD_DATE=$BUILD_DATE
+
 # Add the csv data files
 COPY subject-set.py ./
 RUN mkdir ./data
+
+# ensure we invalidate the docker image cache to rebuild each time (remote data source may change)
+RUN echo building at $BUILD_DATE
 RUN python subject-set.py
 
 # our custom script for converting CSV files to database

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,18 @@ RUN pip install csvs-to-sqlite sqlite-utils panoptes-client
 
 # add BUILD_DATE arg to invalidate the cache
 ARG BUILD_DATE=''
-# bake this into the image for reference
-ENV BUILD_DATE=$BUILD_DATE
 
 # Add the csv data files
 COPY subject-set.py ./
 RUN mkdir ./data
 
-# ensure we invalidate the docker image cache to rebuild each time (remote data source may change)
+# bake this into the image for reference
+# and invalidate the docker image cache to rebuild each time (remote data source may change)
+# https://docs.docker.com/engine/reference/builder/#impact-on-build-caching
+ENV BUILD_DATE=$BUILD_DATE
 RUN echo building at $BUILD_DATE
+
+# build the subject set csv files from the main API
 RUN python subject-set.py
 
 # our custom script for converting CSV files to database

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,12 +9,16 @@ pipeline {
 
   stages {
     stage('Build Subject Set Search API Docker image') {
+      environment {
+        JOB_TIME = sh (returnStdout: true, script: "date '+%A %W %Y %X'").trim()
+      }
       agent any
       steps {
         script {
           def dockerRepoName = 'zooniverse/subject-set-search-api'
           def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
-          def newImage = docker.build(dockerImageName)
+          def buildArgs = "--build-arg BUILD_DATE='${JOB_TIME}' ."
+          def newImage = docker.build(dockerImageName, buildArgs)
           newImage.push()
 
           if (BRANCH_NAME == 'main') {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,8 @@ services:
   datasette:
     build:
       context: .
+      args:
+        BUILD_DATE: 'test-date'
       dockerfile: Dockerfile
     command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/subjects.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000", "--setting", "hash_urls", "1"]
     ports:


### PR DESCRIPTION
ensure we can rebuild with remote source changes and not reuse local image cache.

Do so by injecting a date time variable into the build and invalidate the cache below it's use, https://docs.docker.com/engine/reference/builder/#impact-on-build-caching