### PR TITLE
remove test data project id

### DIFF
--- a/subject-set.py
+++ b/subject-set.py
@@ -4,7 +4,7 @@ from panoptes_client import Project, SubjectSet
 # update this list of project ids
 # to build linked subject sets data files
 # that will be included in the API
-project_ids = [ 12268, 16957 ]
+project_ids = [ 12268 ]
 
 for project_id in project_ids:
 


### PR DESCRIPTION
No need to keep the test project id in the script anymore. I've confirmed this system rebuilds correctly through either jenkins CI `build now` or direct manipulation of the main branch here 🥳 