### PR TITLE
Revert "remove test data project id"

### DIFF
--- a/subject-set.py
+++ b/subject-set.py
@@ -4,7 +4,7 @@ from panoptes_client import Project, SubjectSet
 # update this list of project ids
 # to build linked subject sets data files
 # that will be included in the API
-project_ids = [ 12268 ]
+project_ids = [ 12268, 16957 ]
 
 for project_id in project_ids:
 


### PR DESCRIPTION
Reverts zooniverse/subject-set-search-api#7 - add test project data project back into the API, linked to testing https://frontend.preview.zooniverse.org/projects/camallen/engaging-crowds-tester-project