### PR TITLE
use github container registry as image source

### DIFF
--- a/kubernetes/deployment-production.yaml
+++ b/kubernetes/deployment-production.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: subject-set-search-api-production-app
-          image: zooniverse/subject-set-search-api:latest
+          image: ghcr.io/zooniverse/subject-set-search-api:latest
           resources:
              requests:
                memory: "250Mi"


### PR DESCRIPTION
this PR changes the image source to be the github container registry (GHCR) away from the docker registry. The GH action build code pushes the images to GHCR not docker so we need this change to pull the latest built images.