### PR TITLE
Use latest Datasette

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM datasetteproject/datasette:0.57
+FROM datasetteproject/datasette:latest
 
 WORKDIR /mnt/datasette
 
@@ -32,7 +32,9 @@ RUN /usr/local/bin/import-csv-files-to-sqlite.sh
 COPY ./plugins/ ./databases/plugins/
 COPY settings.json ./databases/
 
+RUN datasette install datasette-hashed-urls
+
 # CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "/mnt/datasette/databases"]
 # fix the dbs not starting in immutable mode, https://github.com/simonw/datasette/pull/1229
-CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/subjects.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000", "--setting", "hash_urls", "1"]
+CMD ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/subjects.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /mnt/datasette
 # for geojson api responses - https://pypi.org/project/geojson/
 RUN pip install csvs-to-sqlite sqlite-utils panoptes-client
 
+# pandas 2.0 breaks csvs-to-sqlite.
+# https://github.com/simonw/csvs-to-sqlite/pull/92
+RUN pip install --force-reinstall "pandas~=1.0"
 # add BUILD_DATE arg to invalidate the cache
 ARG BUILD_DATE=''
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       args:
         BUILD_DATE: 'test-date'
       dockerfile: Dockerfile
-    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/subjects.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000", "--setting", "hash_urls", "1"]
+    command: ["datasette", "-p", "80", "-h", "0.0.0.0", "--cors", "-i", "databases/subjects.db", "--plugins-dir=databases/plugins", "--inspect-file=databases/inspect-data.json", "--setting", "sql_time_limit_ms", "60000",  "--setting", "max_returned_rows", "50000"]
     ports:
       - "8001:80"
     volumes:


### PR DESCRIPTION
- bump the build to `datasette:latest`.
- remove the deprecated `hash_urls` setting.
- install `datasette-hashed-urls`.
- pin `pandas` to 1.0 as a workaround for https://github.com/simonw/csvs-to-sqlite/issues/88.