### PR TITLE
Replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'+%A %W %Y %X')"
+      run: echo "BUILD_DATE=$(date +'+%A %W %Y %X')" >> $GITHUB_OUTPUT
     - name: Build and push
       uses: docker/build-push-action@v3
       with:
@@ -29,7 +29,7 @@ jobs:
           ghcr.io/zooniverse/subject-set-search-api:latest
           ghcr.io/zooniverse/subject-set-search-api:${{ github.sha }}
         build-args: |
-          BUILD_DATE: ${{ steps.date.outputs.date }}
+          BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
   deploy:
     runs-on: ubuntu-latest
     needs: build_and_push_image


### PR DESCRIPTION
`set-output` is deprecated, and replaced by `$GITHUB_OUTPUT`. See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter