### PR TITLE
Use GitHub Actions caching for docker builds

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -5,9 +5,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  build_date:
+    runs-on: ubuntu-latest
+    name: Generate BUILD_DATE
+    steps:
+    - name: Get current date
+      id: date
+      run: echo "BUILD_DATE=$(date +'+%A %W %Y %X')" >> $GITHUB_OUTPUT
+    outputs:
+      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
   build_and_push_image:
     name: Build test image
     runs-on: ubuntu-latest
+    needs: build_date
     steps:
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
@@ -15,10 +25,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Get current date
-      id: date
-      run: echo "BUILD_DATE=$(date +'+%A %W %Y %X')" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -31,4 +37,6 @@ jobs:
           ghcr.io/zooniverse/subject-set-search-api:test
           ghcr.io/zooniverse/subject-set-search-api:${{ github.sha }}
         build-args: |
-          BUILD_DATE=${{ steps.date.outputs.BUILD_DATE }}
+          BUILD_DATE=${{ needs.build_date.outputs.BUILD_DATE }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -7,9 +7,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  build_date:
+    runs-on: ubuntu-latest
+    name: Generate BUILD_DATE
+    steps:
+    - name: Get current date
+      id: date
+      run: echo "BUILD_DATE=$(date +'+%A %W %Y %X')" >> $GITHUB_OUTPUT
+    outputs:
+      BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
   build_and_push_image:
     name: Build production image
     runs-on: ubuntu-latest
+    needs: build_date
     steps:
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
@@ -17,10 +27,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Get current date
-      id: date
-      run: echo "BUILD_DATE=$(date +'+%A %W %Y %X')" >> $GITHUB_OUTPUT
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
@@ -33,7 +39,9 @@ jobs:
           ghcr.io/zooniverse/subject-set-search-api:latest
           ghcr.io/zooniverse/subject-set-search-api:${{ github.sha }}
         build-args: |
-          BUILD_DATE=${{ steps.date.outputs.BUILD_DATE }}
+          BUILD_DATE=${{ needs.build_date.outputs.BUILD_DATE }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
   deploy_production:
     name: Deploy to Production


### PR DESCRIPTION
Towards building the Docker images with our shared CI-CD workflow.
- move the `BUILD_DATE` generator into its own job.
- add `cache-from` and `cache-to` to the build.

This change broke the build in #25 and #19 but the Dockerfile has changed substantially since then, and `BUILD_DATE` is now being passed correctly into each new build. Each new build should fetch fresh CSV data from Panoptes, even if the deployed commit has not changed.