### PR TITLE
Migrate to shared workflows

### DIFF
--- a/.github/workflows/build_branch.yml
+++ b/.github/workflows/build_branch.yml
@@ -14,7 +14,7 @@ jobs:
       run: echo "BUILD_DATE=$(date +'+%A %W %Y %X')" >> $GITHUB_OUTPUT
     outputs:
       BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
-  build_and_push_image:
+  build_image:
     name: Build test image
     runs-on: ubuntu-latest
     needs: build_date

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -17,31 +17,15 @@ jobs:
     outputs:
       BUILD_DATE: ${{ steps.date.outputs.BUILD_DATE }}
   build_and_push_image:
-    name: Build production image
-    runs-on: ubuntu-latest
+    name: Build and Push Image
+    uses: zooniverse/ci-cd/.github/workflows/build_and_push_image.yaml@main
     needs: build_date
-    steps:
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Build and push
-      uses: docker/build-push-action@v4
-      with:
-        push: true
-        tags: |
-          ghcr.io/zooniverse/subject-set-search-api:latest
-          ghcr.io/zooniverse/subject-set-search-api:${{ github.sha }}
-        build-args: |
-          BUILD_DATE=${{ needs.build_date.outputs.BUILD_DATE }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+    with:
+      repo_name: subject-set-search-api
+      commit_id: ${{ github.sha }}
+      latest: true
+      build_args: |
+        BUILD_DATE=${{ needs.build_date.outputs.BUILD_DATE }}
 
   deploy_production:
     name: Deploy to Production


### PR DESCRIPTION
Migrate the production deploy to our shared CI-CD workflow. This should build a new image, with fresh data from Panoptes, each time that it is run manually from the same commit.

The PR branch build doesn't push to GHCR, so I've left that with its own bespoke build script.