### PR TITLE
Add subfolders to ./data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN npm ci
 # Add the csv data files
 COPY src/ ./src
 RUN mkdir ./data
+RUN mkdir ./data/subjects
 
 # add BUILD_DATE arg to invalidate the cache
 ARG BUILD_DATE=''
@@ -51,6 +52,7 @@ FROM builder
 WORKDIR /mnt/datasette
 
 RUN mkdir ./data
+RUN mkdir ./data/subjects
 
 # add BUILD_DATE arg to invalidate the cache
 ARG BUILD_DATE=''

--- a/import-csv-files-to-sqlite.sh
+++ b/import-csv-files-to-sqlite.sh
@@ -5,8 +5,8 @@ rm -f "./databases/*.db"
 
 # run the import csv cmd using csvs-to-sqlite
 echo ---
-echo "Importing ./data/*.csv to db: ./databases/subjects.db"
-csvs-to-sqlite --replace-tables ./data/*.csv ./databases/subjects.db
+echo "Importing ./data/subjects/*.csv to db: ./databases/subjects.db"
+csvs-to-sqlite --replace-tables ./data/subjects/*.csv ./databases/subjects.db
 
 # inspect the databases to create and inspect file
 # used in publishing the database files via datasette

--- a/src/subject-set.js
+++ b/src/subject-set.js
@@ -58,7 +58,7 @@ async function writeCSVFile(subjectSet) {
   const subjects = await getPagedSubjects(subjectSet)
   const cleanSubjects = [...new Set(subjects)]
   const csv = unparse(cleanSubjects)
-  fs.writeFile(`./data/${subjectSet.id}.csv`, csv, onFileWrite)
+  fs.writeFile(`./data/subjects/${subjectSet.id}.csv`, csv, onFileWrite)
   return cleanSubjects
 }
 


### PR DESCRIPTION
## PR Overview

This PR adjusts the subject-sets.js script, import-csv-files-sqlite.sh script, and the Dockerfile so that Subject Sets CSV files are outputted to `./data/subjects` (instead of `./data`)

Context & Notes:
- currently, the subject-sets.js script outputs .csv files to the temporary `./data` folder, and those CSVs then get compiled to `./databases/subjects.db` via import-csv-files-sqlite.sh
- I plan to create parallel Projects script, which means I'd now like to separate the "subjects" data and the "projects" data in the temp `./data` folder
- In a future PR, the Projects script will similarly output to `./data/projects`

### Testing

- Run `docker-compose build` then `docker-compose up`. There should be no issues with the build process. (e.g. no "this folder doesn't exist" errors)
- Open http://127.0.0.1:8001/ . Observe that the Datasette service continues to have the `subjects` database as expected, and that database's tables are populated accordingly.

### Status

Ready for review