### PR TITLE
Community Catalog: performance test 

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -19,6 +19,7 @@ Notes:
 
 const fs = require('fs')
 const { unparse } = require('papaparse')
+const fetchWithRetry = require('./fetchWithRetry')
 
 /*
 Input/Configurables
@@ -38,11 +39,6 @@ const PROJECTS = [
 /*
 --------------------------------------------------------------------------------
  */
-
-const headers = {
-  'Content-Type': 'application/json',
-  Accept: 'application/vnd.api+json; version=1'
-}
 
 async function main() {
   console.log('--------')
@@ -126,13 +122,11 @@ async function fetchSubjectsByPage(projectId = '', page = 1, pageSize = 20) {
   const url = `https://www.zooniverse.org/api/subjects?project_id=${projectId}&page=${page}&page_size=${pageSize}`
   
   try {
-    const res = await fetch(url, { headers })
-    if (!res.ok) throw new Error(`ERROR: fetchSubjectsByPage (${projectId}, ${page}, ${pageSize}`)
-    const { subjects, meta }  = await res.json()
+    const { subjects, meta }  = await fetchWithRetry(url)
     return { subjects, meta: meta.subjects }
   } catch (err) {
     console.error('ERROR: fetchSubjectsByPage()')
-    console.error('- error: ', error)
+    console.error('- error: ', err)
     console.error('- args: ', projectId, page, pageSize)
     throw(err)
   }

--- a/src/projects.js
+++ b/src/projects.js
@@ -34,6 +34,10 @@ const PROJECTS = [
     "name": "Community Catalog (Stable Test Project)",
     "id": 21084,
     "metadata_fields": [ "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language" ]
+  }, {
+    "name": "Scarlets & Blues (Performance Test Only)",  // Feel free to delete once Community Catalog goes live
+    "id": 12268,
+    "metadata_fields": [ "Date", "Page", "image", "Catalogue" ]
   }
 ]
 /*
@@ -118,7 +122,7 @@ Output: (object) {
   meta: (object) contains .count (total items available) and .page_count (total pages available)
 }
  */
-async function fetchSubjectsByPage(projectId = '', page = 1, pageSize = 20) {
+async function fetchSubjectsByPage(projectId = '', page = 1, pageSize = 100) {
   const url = `https://www.zooniverse.org/api/subjects?project_id=${projectId}&page=${page}&page_size=${pageSize}`
   
   try {

--- a/src/projects.js
+++ b/src/projects.js
@@ -55,7 +55,7 @@ async function main() {
   console.log('Subjects fetched: ')
   PROJECTS.forEach((proj, index) => {
     const result = results[index]
-    console.log(`- ${proj.name}: ${(results >= 0) ? results : 'ERROR'}`)
+    console.log(`- ${proj.name}: ${(result >= 0) ? result : 'ERROR'}`)
   })
   console.log('========')
 }


### PR DESCRIPTION
## PR Overview

Related repo: https://github.com/zooniverse/community-catalog
Follows #46

This PR modifies the Projects script for performance testing, specifically by adding Scarlets & Blues (proj_12268) to the `projects` database with 5K subjects.

- Projects script now adds S&B to the projects config list. This is only for testing and can be removed later once the Community Catalog/Communities & Crowds project gets its "proper" project(s) in the config.
- `fetch()` replaced with `fetchWithRetry()`, as per [Jim's suggestion](https://github.com/zooniverse/subject-set-search-api/pull/46#pullrequestreview-1429599078)
- Fetches now pull 100 items per page by default. (Previously, this was 20)
- Minor fixes:
  - fetchSubjectsByPage()'s error catching actually crashed. Derp.
  - main()'s completion status report actually borked when there was > 1 project. 

### Dev Notes

Quick notes on local testing:
- before this PR, projects.js only pulled 10 Subjects from 1 project and ran for about 1s
- after this PR, projects.js pulls 10 + 5212 Subjects from 2 projects, and ran for _14.3s_
- Compare this to subject-set.js's much quicker _10.2s_ run time, which is accomplished by running parallel subject set fetches.

There's clearly room for improvement here; possibly by batch-processing parallel _page_ fetches. Hmm!

For now, an additional 14.3s processing time shouldn't affect our build too much. (When we add new projects, the projects will be fetched in parallel, so the bottleneck will be the project with the largest number of subjects.)

I'll revisit the build performance after I finish updating the frontend and testing for _runtime_ performance. (Though querying 5212 subjects shouldn't strain the system too much; Classroom Maps easily handles 300K items.) (Wait, I thought S&B had way more Subjects than this. This is worth a sanity check with Sam tomorrow.)

### Status

Ready for review!