### PR TITLE
Community Catalog: add 'How Did We Get Here?' to Projects DB

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -38,6 +38,10 @@ const PROJECTS = [
     "name": "Scarlets & Blues (Performance Test Only)",  // Feel free to delete once Community Catalog goes live
     "id": 12268,
     "metadata_fields": [ "Date", "Page", "image", "Catalogue" ]
+  }, {
+    "name": "How Did We Get Here?",
+    "id": 20816,
+    "metadata_fields": [ "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language" ]
   }
 ]
 /*


### PR DESCRIPTION
## PR Overview

Related repo: https://github.com/zooniverse/community-catalog

This PR adds the ["How Did We Get Here?"](https://frontend.preview.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here) Zooniverse project to the Projects database.

This will eventually be viewable on the Community Catalog app, at this URL: https://community-catalog.zooniverse.org/projects/communitiesandcrowds/how-did-we-get-here 