### PR TITLE
Community Catalog: add 'How Did We Get Here?' to Projects DB (Part 2)

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -41,7 +41,10 @@ const PROJECTS = [
   }, {
     "name": "How Did We Get Here?",
     "id": 20816,
-    "metadata_fields": [ "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language" ]
+    "metadata_fields": [
+      "image1", "image2", "internal_id", "group_id", "part_number", "folder", "#Hazard", "condition", "item", "picture_agency", "photographer", "oversize", "sensitive_image", "sensitive_image_note", "problematic_language", "probelmatic_language_notes", "#Other Number", "notes"
+      // Yes, there's a typo in probelmatic_language_notes.
+    ]
   }
 ]
 /*


### PR DESCRIPTION
## PR Overview

Follows #52

Wait, apparently the actual "How Did We Get Here?" project didn't precisely follow the metadata fields used by the "Community Catalog (Stable Test Project)".

This PR amends that, typos and all.