### PR TITLE
Remove csvs-to-sqlite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,8 @@ FROM datasetteproject/datasette:latest AS builder
 WORKDIR /mnt/datasette
 
 # Datasette tools
-# for csv import - https://datasette.io/tools/csvs-to-sqlite
 # for datasette db maniupluations and tools - https://datasette.io/tools/sqlite-utils
-# for geojson api responses - https://pypi.org/project/geojson/
-RUN pip install csvs-to-sqlite sqlite-utils
-
-# pandas 2.0 breaks csvs-to-sqlite.
-# https://github.com/simonw/csvs-to-sqlite/pull/92
-RUN pip install --force-reinstall "pandas~=1.0"
+RUN pip install sqlite-utils
 
 RUN mkdir ./databases
 

--- a/import-csv-files-to-sqlite.sh
+++ b/import-csv-files-to-sqlite.sh
@@ -5,12 +5,21 @@ rm -f "./databases/*.db"
 
 # run the import csv cmd using csvs-to-sqlite
 echo ---
-echo "Importing ./data/subjects/*.csv to db: ./databases/subjects.db"
-csvs-to-sqlite --replace-tables ./data/subjects/*.csv ./databases/subjects.db
+for input_csv_file in $(find ./data/subjects -type f -name *.csv)
+do
+  table_name="$(basename $input_csv_file .csv)"
+  echo "Importing $input_csv_file to table: $table_name in db: ./databases/subjects.db"
+  sqlite-utils insert ./databases/subjects.db $table_name $input_csv_file --csv --replace --detect-types
+done
+
 
 echo ---
-echo "Importing ./data/projects/*.csv to db: ./databases/projects.db"
-csvs-to-sqlite --replace-tables ./data/projects/*.csv ./databases/projects.db
+for input_csv_file in $(find ./data/projects -type f -name *.csv)
+do
+  table_name="$(basename $input_csv_file .csv)"
+  echo "Importing $input_csv_file to table: $table_name in db: ./databases/projects.db"
+  sqlite-utils insert ./databases/projects.db $table_name $input_csv_file --csv --replace --detect-types
+done
 
 # inspect the databases to create and inspect file
 # used in publishing the database files via datasette

--- a/src/projects.js
+++ b/src/projects.js
@@ -159,6 +159,8 @@ async function writeProjectData(project, subjects = []) {
   try {
     const csvRows = formatSubjectsForCsv(subjects, project.metadata_fields)
     const data = unparse(csvRows)
+      .replaceAll(',FALSE', ',0')
+      .replaceAll(',TRUE', ',1')
     const filename = `${OUTPUT_DIR}${TABLE_PREFIX}${project.id}.csv`
     await fs.writeFile(filename, data, 'utf8', onWriteFile)
     return subjects.length

--- a/src/subject-set.js
+++ b/src/subject-set.js
@@ -64,7 +64,9 @@ async function writeCSVFile(subjectSet) {
   const subjects = await getPagedSubjects(subjectSet)
   const cleanSubjects = [...new Set(subjects)]
   const csv = unparse(cleanSubjects)
-  fs.writeFile(`./data/subjects/${subjectSet.id}.csv`, csv, onFileWrite)
+  if (cleanSubjects?.length > 0) {
+    fs.writeFile(`./data/subjects/${subjectSet.id}.csv`, csv, onFileWrite)
+  }
   return cleanSubjects
 }
 


### PR DESCRIPTION
Replace csvs-to-sqlite, which was last updated in 2021 and doesn't support `pandas` 2, with `sqlite-utils`, which is actively maintained.

- Upload CSV files with `sqlite-utils insert --csv --replace --detect-types`.
- Ignore empty subject sets when creating subject set CSV files.
- Convert 'FALSE' and 'TRUE' subject metadata to 0 and 1 in project CSVs.