### PR TITLE
fix: explicitly sort subjects by ID

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -140,7 +140,8 @@ async function fetchSubjectsByPage(projectId = '', page = 1, pageSize = 100) {
     const { subjects, meta }  = await fetchWithRetry('/subjects', {
       project_id: projectId,
       page,
-      page_size: pageSize
+      page_size: pageSize,
+      sort: 'id'
     })
     return { subjects, meta: meta.subjects }
   } catch (err) {

--- a/src/subject-set.js
+++ b/src/subject-set.js
@@ -24,7 +24,8 @@ async function getPagedSubjects(subjectSet, page = 1) {
   const { subjects, meta } = await fetchWithRetry('/subjects', {
     subject_set_id: id,
     page_size: PAGE_SIZE,
-    page
+    page,
+    sort: 'id'
   })
   const rows = subjects.map(subject => subjectMetadataRow(subject, indexFields))
   if (meta.subjects.page_count > page) {


### PR DESCRIPTION
Sort subjects by ID, otherwise the paged API query can duplicate subjects across pages.

- See https://github.com/zooniverse/panoptes/issues/4274.