### PR TITLE
Remove project 18285 (Civil War Bluejackets)

### DIFF
--- a/src/subject-set.js
+++ b/src/subject-set.js
@@ -3,7 +3,7 @@ const { unparse } = require('papaparse')
 
 const fetchWithRetry = require('./fetchWithRetry')
 
-const PROJECT_IDS = [ 12268, 12561, 16957, 5481, 17426, 20163, 18285 ]
+const PROJECT_IDS = [ 12268, 12561, 16957, 5481, 17426, 20163 ]
 const PAGE_SIZE = 100
 
 function subjectMetadataRow(subject, indexFields = []) {


### PR DESCRIPTION
Reverts zooniverse/subject-set-search-api#71

Project does not want to use subject-specific indexing (only subject set selection).