### PR TITLE
Community Catalog: add special compensators for Projects Script

### DIFF
--- a/src/projects.js
+++ b/src/projects.js
@@ -35,11 +35,13 @@ const PROJECTS = [
     "id": 21084,
     "metadata_fields": [ "Item", "Notes", "folder", "image1", "image2", "#Hazard", "Oversize", "group_id", "Condition", "internal_id", "part_number", "Photographer", "#Other Number", "picture_agency", "Sensitive_Image", "Problematic_Language", "Notes on Problematic Language" ]
   }, {
+  /*
     "name": "Scarlets & Blues (Performance Test Only)",  // Feel free to delete once Community Catalog goes live
     "id": 12268,
     "metadata_fields": [ "Date", "Page", "image", "Catalogue" ]
   }, {
-    "name": "How Did We Get Here?",
+  */
+  "name": "How Did We Get Here?",
     "id": 20816,
     "metadata_fields": [
       "image1", "image2", "internal_id", "group_id", "part_number", "folder", "#Hazard", "condition", "item", "picture_agency", "photographer", "oversize", "sensitive_image", "sensitive_image_note", "problematic_language", "probelmatic_language_notes", "#Other Number", "notes"


### PR DESCRIPTION
## PR Overview

Part of: [Community Catalog](https://github.com/zooniverse/community-catalog)

This PR adds "special compensators" for the Projects Script - i.e. rules that smooth out unplanned wonkiness in actual data.

- New compensator: ignore upper/lower case in metadata fields. 
  - Some projects (e.g. Stereovision) don't have consistent metadata fields across Subjects. For example, Subject 1 might have `subject.metadata.file_name`, while Subject 2 might have `subject.metadata.File_Name`.
  - This compensator ensures both metadata fields count as "file_name" (or whatever our config asks for)
  - Config: `myProject.special_compensators. metadata_field_name_ignore_case = true | false` (default: false)

While _ideally_ we would like the actual Subject data in Panoptes to be consistent, we understand that unplanned wonkiness is just a natural facet of the human experience, so the code should try its best to compensate.

### Status

Onwards!