### PR TITLE
Implement recursive fetching of all subject sets

### DIFF
--- a/src/subject-set.js
+++ b/src/subject-set.js
@@ -3,7 +3,7 @@ const { unparse } = require('papaparse')
 
 const fetchWithRetry = require('./fetchWithRetry')
 
-const PROJECT_IDS = [ 24686 ]
+const PROJECT_IDS = [ 12268, 12561, 16957, 5481, 17426, 20163, 24686 ]
 const PAGE_SIZE = 100
 
 function subjectMetadataRow(subject, indexFields = []) {


### PR DESCRIPTION
## Purpose
This PR fixes the limitation on fetching all the subject sets assotiated with a project.

## How To Review
There are two slack messages [[1](https://zooniverse.slack.com/archives/C06LHUC6R/p1760641098919079)] [[2](https://zooniverse.slack.com/archives/C06LHUC6R/p1760648058386409)] describing the problem and the desired solution. This PR implements that solution. The below screenshot is the output of following the testing steps: `subject sets: 330`

<img width="629" height="153" alt="Screenshot 2025-10-17 at 8 00 41 AM" src="https://github.com/user-attachments/assets/90072d56-01b1-473b-8f74-bc4ff40dae29" />

## Test Yourself
- Switch to this branch
- Create `data/subjects` directory in the root of the repo (if you don't already have one)
- Run `node src/subject-set.js` from the terminal
- Wait for it to work... And you should get similar screenshot to the one above